### PR TITLE
Fix report date extraction (#8)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Carpe Vitam - Implementation Status
 
-**Last Updated**: 2026-03-21
+**Last Updated**: 2026-03-22 (issue #8 complete)
 **Phase**: Phase 3 - In Progress (Dashboard Quality)
 
 ---
@@ -196,12 +196,14 @@
 | Issue | Feature | Status |
 |-------|---------|--------|
 | #7 | UI consistency: dark theme across all pages | ✅ Done |
-| #8 | Fix report dates (hard dependency for trend features) | 🔄 In Progress |
+| #8 | Fix report dates (hard dependency for trend features) | ✅ Done |
 | #9 | Trend indicators per analyte | ⬜ Pending #8 |
 | #10 | Analyte detail view (history table + larger chart) | ⬜ Pending #8 |
 | #11 | % deviation from optimal range | ⬜ Pending |
 | #12 | Category summary row | ⬜ Pending |
 | #13 | Lab report linkage on chart tooltips | ⬜ Pending #8 |
+| #15 | Fix misleading FAILED status when no analytes match catalog | ⬜ Open (bug) |
+| #16 | Store unrecognized analytes for catalog review queue | ⬜ Open (feature) |
 
 ---
 

--- a/backend/app/extraction/base.py
+++ b/backend/app/extraction/base.py
@@ -1,9 +1,54 @@
 """Base extractor class and models."""
 
+import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from datetime import date
+from datetime import date, datetime
 from typing import Optional
+
+
+# Keyword prefix that anchors a date to a label in the report
+_DATE_KEYWORD = (
+    r"(?:report\s+date|sample\s+(?:collection\s+)?date|collection\s+date"
+    r"|collected\s+on|reported\s+on|date\s+of\s+(?:report|collection)"
+    r"|test\s+date|date)\s*[:\-]?\s*"
+)
+
+# Patterns tried in order: keyword-anchored first, then any date in text.
+# Each tuple is (regex, list_of_strptime_formats).
+_DATE_PATTERNS: list[tuple[str, list[str]]] = [
+    # --- Keyword-anchored (more reliable) ---
+    (_DATE_KEYWORD + r"(\d{1,2}/\d{1,2}/\d{4})", ["%d/%m/%Y"]),
+    (_DATE_KEYWORD + r"(\d{1,2}-\d{1,2}-\d{4})", ["%d-%m-%Y"]),
+    (_DATE_KEYWORD + r"(\d{1,2}[\s\-]\w{3,9},?\s*\d{4})", ["%d %b %Y", "%d-%b-%Y", "%d %B %Y", "%d-%B-%Y"]),
+    (_DATE_KEYWORD + r"(\d{4}-\d{2}-\d{2})", ["%Y-%m-%d"]),
+    (_DATE_KEYWORD + r"(\d{1,2}\.\d{1,2}\.\d{4})", ["%d.%m.%Y"]),
+    # --- Fallback: first matching date anywhere in text ---
+    (r"\b(\d{2}/\d{2}/\d{4})\b", ["%d/%m/%Y"]),
+    (r"\b(\d{2}-\d{2}-\d{4})\b", ["%d-%m-%Y"]),
+    (r"\b(\d{1,2}\s+\w{3,9},?\s*\d{4})\b", ["%d %b %Y", "%d %B %Y"]),
+    (r"\b(\d{4}-\d{2}-\d{2})\b", ["%Y-%m-%d"]),
+    (r"\b(\d{2}\.\d{2}\.\d{4})\b", ["%d.%m.%Y"]),
+]
+
+
+def extract_report_date(text: str) -> Optional[date]:
+    """Extract a report date from text.
+
+    Tries keyword-anchored patterns first (e.g. "Report Date: 22/03/2026"),
+    then falls back to the first date found anywhere in the text.
+    """
+    for pattern, fmts in _DATE_PATTERNS:
+        match = re.search(pattern, text, re.IGNORECASE)
+        if not match:
+            continue
+        raw = match.group(1).replace(",", "").strip()
+        for fmt in fmts:
+            try:
+                return datetime.strptime(raw, fmt).date()
+            except ValueError:
+                continue
+    return None
 
 
 @dataclass

--- a/backend/app/extraction/extractors/generic_pdf.py
+++ b/backend/app/extraction/extractors/generic_pdf.py
@@ -1,11 +1,10 @@
 """Generic PDF extractor - works with various lab report formats."""
 
 import re
-from datetime import date, datetime
 from typing import Optional
 import pdfplumber
 
-from ..base import BaseExtractor, ExtractorOutput, ExtractedTestResult
+from ..base import BaseExtractor, ExtractorOutput, ExtractedTestResult, extract_report_date
 from ..registry import ExtractorRegistry
 
 
@@ -35,7 +34,7 @@ class GenericPDFExtractor(BaseExtractor):
 
                 # Extract metadata
                 patient_name = self._extract_patient_name(full_text)
-                report_date = self._extract_date(full_text)
+                report_date = extract_report_date(full_text)
 
                 # Try table extraction first
                 tests = await self._extract_from_tables(pdf)
@@ -68,24 +67,6 @@ class GenericPDFExtractor(BaseExtractor):
         match = re.search(r"Name\s*:\s*(.*?)\(", text)
         if match:
             return match.group(1).strip()
-        return None
-
-    def _extract_date(self, text: str) -> Optional[date]:
-        """Extract report date from text."""
-        for pattern, fmts in [
-            (r"\d{2}/\d{2}/\d{4}", ["%d/%m/%Y"]),
-            (r"\d{2}-\d{2}-\d{4}", ["%d-%m-%Y"]),
-            (r"\d{2} \w{3},? \d{4}", ["%d %b %Y", "%d %B %Y"]),
-        ]:
-            match = re.search(pattern, text)
-            if not match:
-                continue
-            raw = match.group(0).replace(",", "")
-            for fmt in fmts:
-                try:
-                    return datetime.strptime(raw, fmt).date()
-                except ValueError:
-                    continue
         return None
 
     async def _extract_from_tables(self, pdf) -> list[ExtractedTestResult]:

--- a/backend/app/extraction/extractors/redcliffe_pdf.py
+++ b/backend/app/extraction/extractors/redcliffe_pdf.py
@@ -1,11 +1,10 @@
 """Redcliffe Labs PDF extractor."""
 
 import re
-from datetime import date, datetime
 from typing import Optional
 import pdfplumber
 
-from ..base import BaseExtractor, ExtractorOutput, ExtractedTestResult
+from ..base import BaseExtractor, ExtractorOutput, ExtractedTestResult, extract_report_date
 from ..registry import ExtractorRegistry
 
 
@@ -36,7 +35,7 @@ class RedcliffePDFExtractor(BaseExtractor):
                         full_text += text + "\n"
 
                 patient_name = self._extract_patient_name(full_text)
-                report_date = self._extract_date(full_text)
+                report_date = extract_report_date(full_text)
                 tests = await self._extract_from_tables(pdf)
 
                 if not tests:
@@ -69,23 +68,6 @@ class RedcliffePDFExtractor(BaseExtractor):
             match = re.search(pattern, text, re.IGNORECASE)
             if match:
                 return match.group(1).strip()
-        return None
-
-    def _extract_date(self, text: str) -> Optional[date]:
-        for pattern, fmts in [
-            (r"\d{2}/\d{2}/\d{4}", ["%d/%m/%Y"]),
-            (r"\d{2}-\d{2}-\d{4}", ["%d-%m-%Y"]),
-            (r"\d{2} \w{3},? \d{4}", ["%d %b %Y", "%d %B %Y"]),
-        ]:
-            match = re.search(pattern, text)
-            if not match:
-                continue
-            raw = match.group(0).replace(",", "")
-            for fmt in fmts:
-                try:
-                    return datetime.strptime(raw, fmt).date()
-                except ValueError:
-                    continue
         return None
 
     async def _extract_from_tables(self, pdf) -> list[ExtractedTestResult]:

--- a/backend/app/extraction/extractors/thyrocare_pdf.py
+++ b/backend/app/extraction/extractors/thyrocare_pdf.py
@@ -1,11 +1,10 @@
 """Thyrocare PDF extractor."""
 
 import re
-from datetime import date
 from typing import Optional
 import pdfplumber
 
-from ..base import BaseExtractor, ExtractorOutput, ExtractedTestResult
+from ..base import BaseExtractor, ExtractorOutput, ExtractedTestResult, extract_report_date
 from ..registry import ExtractorRegistry
 
 
@@ -37,7 +36,7 @@ class ThyrocarePDFExtractor(BaseExtractor):
                         full_text += text + "\n"
 
                 patient_name = self._extract_patient_name(full_text)
-                report_date = self._extract_date(full_text)
+                report_date = extract_report_date(full_text)
                 tests = await self._extract_from_tables(pdf)
 
                 if not tests:
@@ -70,29 +69,6 @@ class ThyrocarePDFExtractor(BaseExtractor):
             match = re.search(pattern, text)
             if match:
                 return match.group(1).strip()
-        return None
-
-    def _extract_date(self, text: str) -> Optional[date]:
-        from datetime import datetime
-        # Thyrocare uses "DD Mon YYYY", "DD Mon, YYYY", or "DD/MM/YYYY"
-        for pattern, fmt in [
-            (r"\d{2} \w{3},? \d{4}", None),
-            (r"\d{2}/\d{2}/\d{4}", "%d/%m/%Y"),
-        ]:
-            match = re.search(pattern, text)
-            if not match:
-                continue
-            raw = match.group(0).replace(",", "")
-            if fmt:
-                try:
-                    return datetime.strptime(raw, fmt).date()
-                except ValueError:
-                    continue
-            for f in ("%d %b %Y", "%d %B %Y"):
-                try:
-                    return datetime.strptime(raw, f).date()
-                except ValueError:
-                    continue
         return None
 
     async def _extract_from_tables(self, pdf) -> list[ExtractedTestResult]:

--- a/backend/app/routers/uploads.py
+++ b/backend/app/routers/uploads.py
@@ -1,3 +1,6 @@
+from datetime import date
+from typing import Optional
+
 from fastapi import APIRouter, Depends, HTTPException, status, File, UploadFile, Form, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,6 +19,7 @@ router = APIRouter()
 async def upload_pdf(
     file: UploadFile = File(...),
     family_member_id: str = Form(...),
+    report_date: Optional[date] = Form(None),
     db: AsyncSession = Depends(get_db_session),
     current_user = Depends(get_current_user),
 ):
@@ -35,6 +39,7 @@ async def upload_pdf(
             filename=file.filename,
             family_member_id=family_member_id,
             uploaded_by_user_id=current_user.id,
+            report_date=report_date,
         )
 
         # Trigger extraction synchronously (Phase 3 will use async queue)

--- a/backend/app/services/upload_service.py
+++ b/backend/app/services/upload_service.py
@@ -2,8 +2,9 @@
 
 import uuid
 import os
-from datetime import datetime
+from datetime import date, datetime
 from pathlib import Path
+from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 
@@ -27,6 +28,7 @@ class UploadService:
         filename: str,
         family_member_id: str,
         uploaded_by_user_id: str,
+        report_date: Optional[date] = None,
     ) -> LabReport:
         """
         Receive and store an uploaded PDF.
@@ -61,6 +63,7 @@ class UploadService:
             uploaded_by_user_id=uploaded_by_user_id,
             original_filename=filename,
             storage_path=storage_path,
+            report_date=report_date,  # user-provided fallback; overwritten if extractor finds a date
             extraction_status=ExtractionStatus.PENDING,
             created_at=datetime.utcnow(),
             updated_at=datetime.utcnow(),

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -6,6 +6,7 @@ import { familiesAPI, type Family, type FamilyMember } from '../api/families'
 export default function UploadPage() {
   const navigate = useNavigate()
   const [file, setFile] = useState<File | null>(null)
+  const [reportDate, setReportDate] = useState('')
   const [uploading, setUploading] = useState(false)
   const [uploadStatus, setUploadStatus] = useState<'idle' | 'uploading' | 'success' | 'error'>('idle')
   const [error, setError] = useState('')
@@ -90,6 +91,7 @@ export default function UploadPage() {
       const formData = new FormData()
       formData.append('file', file)
       formData.append('family_member_id', selectedMemberId)
+      if (reportDate) formData.append('report_date', reportDate)
 
       await apiClient.post('/uploads', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
@@ -223,6 +225,19 @@ export default function UploadPage() {
               >
                 {file ? file.name : 'Choose PDF file...'}
               </button>
+            </div>
+
+            {/* Report date (optional fallback if extraction fails) */}
+            <div>
+              <label style={labelStyle}>
+                Report Date <span style={{ color: '#6b7280', fontWeight: 400 }}>(optional — used if not found in PDF)</span>
+              </label>
+              <input
+                type="date"
+                value={reportDate}
+                onChange={(e) => setReportDate(e.target.value)}
+                style={{ ...inputStyle, colorScheme: 'dark' }}
+              />
             </div>
 
             {error && (


### PR DESCRIPTION
## Summary

- Add shared `extract_report_date()` to `base.py` — keyword-anchored patterns (`Report Date:`, `Collection Date:`, `Collected On:`, etc.) tried first, then first date found anywhere in text
- Expand format support to include `DD.MM.YYYY`, `YYYY-MM-DD`, `DD-Mon-YYYY` alongside existing formats
- Remove duplicated `_extract_date()` from all three extractors (generic, Thyrocare, Redcliffe)
- Add optional `report_date` form field to the upload endpoint as a user-provided fallback when extraction finds no date
- Wire through `upload_service.py` and add a date picker to `UploadPage.tsx`

## Test plan

- [ ] Upload a Thyrocare PDF — verify `report_date` is populated in `lab_reports`
- [ ] Upload a PDF with no recognisable date format — verify date picker fallback is sent and stored
- [ ] Confirm dashboard timeseries x-axis shows real dates

Closes #8