### PR TITLE
Add analyte detail view (#10)

### DIFF
--- a/frontend/src/api/results.ts
+++ b/frontend/src/api/results.ts
@@ -11,6 +11,9 @@ export interface TimeSeriesSeries {
   analyte_id: string
   analyte_name: string
   unit: string
+  category: string | null
+  ref_low: number | null
+  ref_high: number | null
   datapoints: TimeSeriesDatapoint[]
 }
 

--- a/frontend/src/components/dashboard/AnalyteCard.tsx
+++ b/frontend/src/components/dashboard/AnalyteCard.tsx
@@ -3,6 +3,7 @@ import { TimeSeriesSeries } from '../../api/results'
 
 interface AnalyteCardProps {
   series: TimeSeriesSeries
+  onClick: () => void
 }
 
 function getStatus(value: number | null | undefined, refLow: number | null | undefined, refHigh: number | null | undefined) {
@@ -20,7 +21,7 @@ const STATUS = {
 }
 const DEFAULT_STATUS = { bg: '#374151', color: '#d1d5db', line: '#6b7280' }
 
-export default function AnalyteCard({ series }: AnalyteCardProps) {
+export default function AnalyteCard({ series, onClick }: AnalyteCardProps) {
   const latest = series.datapoints[series.datapoints.length - 1]
   const status = getStatus(latest?.value, series.ref_low, series.ref_high)
   const style = status ? STATUS[status] : DEFAULT_STATUS
@@ -33,7 +34,10 @@ export default function AnalyteCard({ series }: AnalyteCardProps) {
   const max = allPoints.length ? Math.max(...allPoints) * 1.15 : 100
 
   return (
-    <div style={{ backgroundColor: '#1f2937', borderRadius: '0.75rem', padding: '1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+    <div
+      onClick={onClick}
+      style={{ backgroundColor: '#1f2937', borderRadius: '0.75rem', padding: '1rem', display: 'flex', flexDirection: 'column', gap: '0.5rem', cursor: 'pointer' }}
+    >
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
         <span style={{ color: '#ffffff', fontWeight: 600, fontSize: '0.875rem' }}>{series.analyte_name}</span>
         {status && (

--- a/frontend/src/components/dashboard/AnalyteDetailModal.tsx
+++ b/frontend/src/components/dashboard/AnalyteDetailModal.tsx
@@ -1,0 +1,216 @@
+import { useEffect } from 'react'
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip,
+  ReferenceArea, ReferenceLine, ResponsiveContainer,
+} from 'recharts'
+import { TimeSeriesSeries } from '../../api/results'
+
+interface Props {
+  series: TimeSeriesSeries
+  onClose: () => void
+}
+
+function getStatus(value: number | null | undefined, refLow: number | null | undefined, refHigh: number | null | undefined) {
+  if (value == null) return null
+  if (refLow != null && value < refLow) return 'Low'
+  if (refHigh != null && value > refHigh) return 'High'
+  if (refLow != null || refHigh != null) return 'Optimal'
+  return null
+}
+
+const STATUS = {
+  Low:     { bg: '#78350f', color: '#fcd34d', line: '#f59e0b' },
+  High:    { bg: '#7f1d1d', color: '#fca5a5', line: '#ef4444' },
+  Optimal: { bg: '#1e3a8a', color: '#93c5fd', line: '#3b82f6' },
+}
+const DEFAULT_STATUS = { bg: '#374151', color: '#d1d5db', line: '#6b7280' }
+
+function formatDate(dateStr: string) {
+  if (!dateStr) return '—'
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+}
+
+function formatDateShort(dateStr: string) {
+  if (!dateStr) return ''
+  const d = new Date(dateStr)
+  return d.toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+}
+
+export default function AnalyteDetailModal({ series, onClose }: Props) {
+  // Close on Escape
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [onClose])
+
+  const latest = series.datapoints[series.datapoints.length - 1]
+  const status = getStatus(latest?.value, series.ref_low, series.ref_high)
+  const style = status ? STATUS[status] : DEFAULT_STATUS
+
+  const chartData = series.datapoints.map((dp) => ({
+    date: dp.date,
+    value: dp.value,
+    label: formatDateShort(dp.date),
+  }))
+
+  const values = series.datapoints.map((d) => d.value).filter((v): v is number => v != null)
+  const allPoints = [...values, series.ref_low, series.ref_high].filter((v): v is number => v != null)
+  const min = allPoints.length ? Math.min(...allPoints) * 0.85 : 0
+  const max = allPoints.length ? Math.max(...allPoints) * 1.15 : 100
+
+  // History rows newest-first
+  const rows = [...series.datapoints].reverse()
+
+  return (
+    <div
+      onClick={onClose}
+      style={{
+        position: 'fixed', inset: 0, zIndex: 50,
+        backgroundColor: 'rgba(0,0,0,0.7)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: '1rem',
+      }}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          backgroundColor: '#111827', borderRadius: '0.75rem',
+          border: '1px solid #1f2937', width: '100%', maxWidth: '720px',
+          maxHeight: '90vh', overflowY: 'auto', padding: '1.5rem',
+          display: 'flex', flexDirection: 'column', gap: '1.25rem',
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start' }}>
+          <div>
+            <h2 style={{ color: '#ffffff', fontWeight: 700, fontSize: '1.25rem', margin: 0 }}>
+              {series.analyte_name}
+            </h2>
+            {series.category && (
+              <span style={{ color: '#6b7280', fontSize: '0.75rem' }}>{series.category}</span>
+            )}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '0.75rem' }}>
+            {status && (
+              <span style={{ backgroundColor: style.bg, color: style.color, fontSize: '0.75rem', padding: '0.25rem 0.75rem', borderRadius: '9999px', fontWeight: 500 }}>
+                {status}
+              </span>
+            )}
+            <button
+              onClick={onClose}
+              style={{ background: 'none', border: 'none', color: '#6b7280', cursor: 'pointer', fontSize: '1.25rem', lineHeight: 1, padding: '0.25rem' }}
+            >
+              ✕
+            </button>
+          </div>
+        </div>
+
+        {/* Latest value */}
+        {latest?.value != null && (
+          <div>
+            <span style={{ fontSize: '2rem', fontWeight: 700, color: style.line }}>{latest.value}</span>
+            <span style={{ color: '#9ca3af', fontSize: '1rem', marginLeft: '0.375rem' }}>{series.unit}</span>
+            {latest.date && (
+              <span style={{ color: '#6b7280', fontSize: '0.875rem', marginLeft: '0.75rem' }}>
+                as of {formatDate(latest.date)}
+              </span>
+            )}
+          </div>
+        )}
+
+        {(series.ref_low != null || series.ref_high != null) && (
+          <div style={{ color: '#6b7280', fontSize: '0.875rem' }}>
+            Optimal range: {series.ref_low ?? '—'} – {series.ref_high ?? '—'} {series.unit}
+          </div>
+        )}
+
+        {/* Large chart */}
+        <div style={{ height: 220 }}>
+          <ResponsiveContainer width="100%" height={220}>
+            <LineChart data={chartData} margin={{ top: 8, right: 16, left: 0, bottom: 8 }}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#1f2937" />
+              <XAxis
+                dataKey="label"
+                tick={{ fill: '#9ca3af', fontSize: 11 }}
+                axisLine={{ stroke: '#374151' }}
+                tickLine={false}
+              />
+              <YAxis
+                domain={[min, max]}
+                tick={{ fill: '#9ca3af', fontSize: 11 }}
+                axisLine={false}
+                tickLine={false}
+                width={48}
+                tickFormatter={(v: number) => String(v)}
+              />
+              <Tooltip
+                contentStyle={{ backgroundColor: '#1f2937', border: '1px solid #374151', borderRadius: '0.375rem', color: '#ffffff' }}
+                labelStyle={{ color: '#9ca3af', marginBottom: '0.25rem' }}
+                formatter={(value: number) => [`${value} ${series.unit}`, series.analyte_name]}
+              />
+              {series.ref_low != null && series.ref_high != null && (
+                <ReferenceArea y1={series.ref_low} y2={series.ref_high} fill="#166534" fillOpacity={0.25} />
+              )}
+              {series.ref_low != null && (
+                <ReferenceLine y={series.ref_low} stroke="#166534" strokeDasharray="3 3" strokeWidth={1} />
+              )}
+              {series.ref_high != null && (
+                <ReferenceLine y={series.ref_high} stroke="#166534" strokeDasharray="3 3" strokeWidth={1} />
+              )}
+              <Line
+                type="monotone"
+                dataKey="value"
+                stroke={style.line}
+                strokeWidth={2}
+                dot={{ r: 4, fill: style.line, strokeWidth: 0 }}
+                activeDot={{ r: 6 }}
+                isAnimationActive={false}
+              />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+
+        {/* History table */}
+        <div>
+          <h3 style={{ color: '#9ca3af', fontSize: '0.75rem', fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.05em', marginBottom: '0.5rem' }}>
+            History
+          </h3>
+          <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '0.875rem' }}>
+            <thead>
+              <tr style={{ borderBottom: '1px solid #1f2937' }}>
+                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem', color: '#6b7280', fontWeight: 500 }}>Date</th>
+                <th style={{ textAlign: 'right', padding: '0.5rem 0.75rem', color: '#6b7280', fontWeight: 500 }}>Value</th>
+                <th style={{ textAlign: 'left', padding: '0.5rem 0.75rem', color: '#6b7280', fontWeight: 500 }}>Unit</th>
+                <th style={{ textAlign: 'center', padding: '0.5rem 0.75rem', color: '#6b7280', fontWeight: 500 }}>Status</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((dp, i) => {
+                const rowStatus = getStatus(dp.value, series.ref_low, series.ref_high)
+                const rowStyle = rowStatus ? STATUS[rowStatus] : DEFAULT_STATUS
+                return (
+                  <tr key={i} style={{ borderBottom: '1px solid #1f2937' }}>
+                    <td style={{ padding: '0.625rem 0.75rem', color: '#d1d5db' }}>{formatDate(dp.date)}</td>
+                    <td style={{ padding: '0.625rem 0.75rem', color: rowStyle.line, fontWeight: 600, textAlign: 'right' }}>
+                      {dp.value ?? '—'}
+                    </td>
+                    <td style={{ padding: '0.625rem 0.75rem', color: '#9ca3af' }}>{series.unit}</td>
+                    <td style={{ padding: '0.625rem 0.75rem', textAlign: 'center' }}>
+                      {rowStatus ? (
+                        <span style={{ backgroundColor: rowStyle.bg, color: rowStyle.color, fontSize: '0.7rem', padding: '0.125rem 0.5rem', borderRadius: '9999px', fontWeight: 500 }}>
+                          {rowStatus}
+                        </span>
+                      ) : '—'}
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -4,6 +4,7 @@ import { useAuthStore } from '../store/authStore'
 import { familiesAPI, type Family, type FamilyMember } from '../api/families'
 import { resultsAPI, type TimeSeriesSeries } from '../api/results'
 import AnalyteCard from '../components/dashboard/AnalyteCard'
+import AnalyteDetailModal from '../components/dashboard/AnalyteDetailModal'
 
 export default function DashboardPage() {
   const navigate = useNavigate()
@@ -16,6 +17,7 @@ export default function DashboardPage() {
 
   const [allSeries, setAllSeries] = useState<TimeSeriesSeries[]>([])
   const [loadingChart, setLoadingChart] = useState(false)
+  const [selectedSeries, setSelectedSeries] = useState<TimeSeriesSeries | null>(null)
 
   const grouped = allSeries.reduce<Record<string, TimeSeriesSeries[]>>((acc, s) => {
     const cat = s.category ?? 'Other'
@@ -150,11 +152,15 @@ export default function DashboardPage() {
               {category}
             </h3>
             <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: '1rem' }}>
-              {series.map((s) => <AnalyteCard key={s.analyte_id} series={s} />)}
+              {series.map((s) => <AnalyteCard key={s.analyte_id} series={s} onClick={() => setSelectedSeries(s)} />)}
             </div>
           </div>
         ))}
       </main>
+
+      {selectedSeries && (
+        <AnalyteDetailModal series={selectedSeries} onClose={() => setSelectedSeries(null)} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Clicking any analyte card on the dashboard opens a detail modal
- Modal contains:
  - Analyte name, category, status badge
  - Latest value with unit and date
  - Optimal range (if available)
  - Full-width Recharts chart with date x-axis, tooltip, and reference range band
  - History table (newest-first) with Date / Value / Unit / Status columns, colour-coded per row
- Modal closes on Escape key or clicking the backdrop
- Fixed `TimeSeriesSeries` TypeScript type to include `category`, `ref_low`, `ref_high` (were missing from the interface despite being returned by the API)

## Test plan

- [ ] Click an analyte card — modal opens with correct name and values
- [ ] Chart shows dates on x-axis with a dot per data point
- [ ] History table lists all readings newest-first with correct status colours
- [ ] Escape key and backdrop click both close the modal

Closes #10