### PR TITLE
Fix login not populating user ID in auth store

### DIFF
--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -18,13 +18,15 @@ export default function LoginPage() {
 
     try {
       const response = await authAPI.login({ email, password })
+      setAuth(null, response.access_token)
+      const userInfo = await authAPI.getCurrentUser()
       setAuth(
         {
-          id: '',
-          email,
-          display_name: '',
-          is_active: true,
-          is_admin: false,
+          id: userInfo.id,
+          email: userInfo.email,
+          display_name: userInfo.display_name,
+          is_active: userInfo.is_active,
+          is_admin: userInfo.is_admin,
         },
         response.access_token
       )


### PR DESCRIPTION
## Summary
- Login was storing `id: ''` in the auth store instead of the real user ID
- This made `currentUserIsAdmin` always false, hiding the Manage Members panel for admin users
- Fix: call `/auth/me` after login to get the real user object before navigating

## Test plan
- [ ] Log out and log back in as an admin user
- [ ] Manage Members panel is visible on the dashboard
- [ ] Non-admin users do not see the panel

Closes #28