### PR TITLE
Fix reference ranges not surfacing in time series API

### DIFF
--- a/backend/alembic/env.py
+++ b/backend/alembic/env.py
@@ -20,8 +20,9 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# set the sqlalchemy.url from environment or settings
-config.set_main_option("sqlalchemy.url", settings.database_url)
+# set the sqlalchemy.url from environment or settings (sync driver for migrations)
+sync_url = settings.database_url.replace("postgresql+asyncpg://", "postgresql://")
+config.set_main_option("sqlalchemy.url", sync_url)
 
 # Model's MetaData object for 'autogenerate' support
 target_metadata = Base.metadata
@@ -46,7 +47,7 @@ def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
 
     configuration = config.get_section(config.config_ini_section)
-    configuration["sqlalchemy.url"] = settings.database_url
+    configuration["sqlalchemy.url"] = sync_url
     connectable = engine_from_config(
         configuration,
         prefix="sqlalchemy.",

--- a/backend/alembic/versions/002_add_sex_to_users.py
+++ b/backend/alembic/versions/002_add_sex_to_users.py
@@ -1,0 +1,21 @@
+"""Add sex to users table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-03-22
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = '002'
+down_revision = '001'
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('sex', sa.String(10), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('users', 'sex')

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -15,6 +15,7 @@ class User(Base):
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False, index=True)
     display_name: Mapped[str] = mapped_column(String(255), nullable=False)
     hashed_password: Mapped[str] = mapped_column(String(255), nullable=False)
+    sex: Mapped[str | None] = mapped_column(String(10), nullable=True)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, nullable=False)

--- a/backend/app/routers/families.py
+++ b/backend/app/routers/families.py
@@ -33,6 +33,7 @@ async def create_family(
         family_id=family.id,
         user_id=current_user.id,
         display_name=current_user.display_name,
+        sex=current_user.sex,
         role=FamilyMemberRole.ADMIN,
     )
     db.add(admin_member)

--- a/backend/app/routers/results.py
+++ b/backend/app/routers/results.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter, Depends, HTTPException, status, Query
-from sqlalchemy import select
+from sqlalchemy import select, or_
 from sqlalchemy.orm import selectinload
 from sqlalchemy.ext.asyncio import AsyncSession
 from datetime import datetime
@@ -7,7 +7,8 @@ from datetime import datetime
 from ..database import get_db_session
 from ..dependencies import get_current_user
 from ..models.test_result import TestResult
-from ..models.analyte import AnalyteCatalog
+from ..models.analyte import AnalyteCatalog, ReferenceRange
+from ..models.family import FamilyMember
 from ..schemas.results import TestResultSchema, TimeSeriesResponseSchema, TimeSeriesSeries, TimeSeriesDatapoint
 
 router = APIRouter()
@@ -105,23 +106,46 @@ async def get_timeseries(
 
         series_map[test_result.analyte_id]["datapoints"].append(test_result)
 
+    # Get family member's sex for sex-specific range lookup
+    member_result = await db.execute(select(FamilyMember).where(FamilyMember.id == family_member_id))
+    member = member_result.scalar_one_or_none()
+    member_sex = member.sex if member else None
+
+    # Fetch reference ranges — sex-specific (if member sex known) and sex-neutral
+    sex_filter = (
+        or_(ReferenceRange.sex == member_sex, ReferenceRange.sex.is_(None))
+        if member_sex
+        else ReferenceRange.sex.is_(None)
+    )
+    rr_result = await db.execute(
+        select(ReferenceRange).where(
+            ReferenceRange.analyte_id.in_(list(series_map.keys())),
+            sex_filter,
+        )
+    )
+    # Prefer sex-specific over sex-neutral when both exist
+    ref_ranges: dict[str, ReferenceRange] = {}
+    for rr in rr_result.scalars().all():
+        if rr.analyte_id not in ref_ranges or rr.sex is not None:
+            ref_ranges[rr.analyte_id] = rr
+
     # Build response
     series = []
     for analyte_id, data in series_map.items():
         analyte = data["analyte"]
+        rr = ref_ranges.get(analyte_id)
+        ref_low = rr.low_normal if rr else None
+        ref_high = rr.high_normal if rr else None
+
         datapoints = [
             TimeSeriesDatapoint(
                 date=str(tr.report_date) if tr.report_date else "",
                 value=tr.canonical_value,
-                ref_low=tr.ref_low,
-                ref_high=tr.ref_high,
+                ref_low=ref_low,
+                ref_high=ref_high,
             )
             for tr in data["datapoints"]
         ]
-
-        # Use ref range from most recent datapoint (same for all)
-        ref_low = data["datapoints"][-1].ref_low if data["datapoints"] else None
-        ref_high = data["datapoints"][-1].ref_high if data["datapoints"] else None
 
         series.append(TimeSeriesSeries(
             analyte_id=analyte.id,

--- a/backend/app/schemas/auth.py
+++ b/backend/app/schemas/auth.py
@@ -2,6 +2,7 @@
 
 from datetime import datetime
 
+from typing import Optional
 from pydantic import BaseModel, EmailStr, Field
 
 
@@ -11,6 +12,7 @@ class UserRegisterSchema(BaseModel):
     email: EmailStr
     display_name: str = Field(..., min_length=1, max_length=255)
     password: str = Field(..., min_length=8, max_length=255)
+    sex: Optional[str] = Field(None, pattern="^(M|F)$")
 
 
 class UserLoginSchema(BaseModel):
@@ -33,6 +35,7 @@ class UserSchema(BaseModel):
     id: str
     email: str
     display_name: str
+    sex: Optional[str]
     is_active: bool
     is_admin: bool
     created_at: datetime

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -48,6 +48,7 @@ async def register_user(db: AsyncSession, user_data: UserRegisterSchema) -> User
         email=user_data.email,
         display_name=user_data.display_name,
         hashed_password=hash_password(user_data.password),
+        sex=user_data.sex,
         is_active=True,
     )
     db.add(user)

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -4,6 +4,7 @@ export interface RegisterRequest {
   email: string
   display_name: string
   password: string
+  sex?: string
 }
 
 export interface LoginRequest {

--- a/frontend/src/pages/RegisterPage.tsx
+++ b/frontend/src/pages/RegisterPage.tsx
@@ -8,6 +8,7 @@ export default function RegisterPage() {
   const setAuth = useAuthStore((state) => state.setAuth)
   const [email, setEmail] = useState('')
   const [displayName, setDisplayName] = useState('')
+  const [sex, setSex] = useState('')
   const [password, setPassword] = useState('')
   const [confirmPassword, setConfirmPassword] = useState('')
   const [error, setError] = useState('')
@@ -34,14 +35,17 @@ export default function RegisterPage() {
         email,
         display_name: displayName,
         password,
+        sex: sex || undefined,
       })
+      setAuth(null, response.access_token)
+      const userInfo = await authAPI.getCurrentUser()
       setAuth(
         {
-          id: '',
-          email,
-          display_name: displayName,
-          is_active: true,
-          is_admin: false,
+          id: userInfo.id,
+          email: userInfo.email,
+          display_name: userInfo.display_name,
+          is_active: userInfo.is_active,
+          is_admin: userInfo.is_admin,
         },
         response.access_token
       )
@@ -84,6 +88,20 @@ export default function RegisterPage() {
               required
               style={inputStyle}
             />
+          </div>
+
+          <div>
+            <label htmlFor="sex" style={labelStyle}>Sex <span style={{ color: '#6b7280', fontWeight: 400 }}>(optional — used for reference ranges)</span></label>
+            <select
+              id="sex"
+              value={sex}
+              onChange={(e) => setSex(e.target.value)}
+              style={{ ...inputStyle, backgroundColor: '#1f2937' }}
+            >
+              <option value="">Prefer not to say</option>
+              <option value="M">Male</option>
+              <option value="F">Female</option>
+            </select>
           </div>
 
           <div>


### PR DESCRIPTION
## Summary
- Time series endpoint was reading `ref_low`/`ref_high` from `test_results` (always null) instead of the `reference_ranges` table
- Now queries `reference_ranges` by analyte ID, preferring sex-specific ranges when the family member's sex is known, falling back to sex-neutral
- Adds `sex` column to `users` table (migration 002) so it can be captured at registration and propagated to the initial family member on family creation
- Fixes `alembic/env.py` to use sync DB URL for migrations

## Test plan
- [x] Reference bands visible on analyte cards for analytes with sex-neutral ranges (e.g. Amylase, Fasting Blood Sugar)
- [x] Testosterone shows reference band for male member (sex-specific range M: 264–916)
- [x] Optimal/Low/High status badges fire correctly
- [x] Sex dropdown visible on registration page
- [x] API starts cleanly after restart

Closes #31